### PR TITLE
Fix thread leak in BurpExtender

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -43,8 +43,11 @@ public class BurpExtender implements IBurpExtender, IContextMenuFactory {
     }
 
     private void runScannerForRequest(IHttpRequestResponse iHttpRequestResponse) {
-        ExecutorService service = Executors.newFixedThreadPool(4);
-        service.execute(new ScannerThread(iHttpRequestResponse));
+        // Using a new thread avoids leaking ExecutorService threads for each
+        // menu invocation. Previously a new fixed thread pool was created per
+        // request without being shutdown which exhausted resources over time.
+        Thread t = new Thread(new ScannerThread(iHttpRequestResponse));
+        t.start();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid spawning a new fixed thread pool for every scan
- start a single thread per scan request

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848697c607c8332b90c98240e7862bc